### PR TITLE
convert to Swift2

### DIFF
--- a/SwiftHTTP.xcodeproj/project.pbxproj
+++ b/SwiftHTTP.xcodeproj/project.pbxproj
@@ -95,7 +95,9 @@
 		BB6925E91AACD33700D6BFB3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftMigration = 0710;
+				LastSwiftUpdateCheck = 0710;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = bytieful;
 				TargetAttributes = {
 					BB6925F01AACD33700D6BFB3 = {
@@ -177,6 +179,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -241,6 +244,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = SwiftHTTP/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bytieful.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -252,6 +256,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = SwiftHTTP/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.bytieful.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -275,6 +280,7 @@
 				BB69260D1AACD33700D6BFB3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SwiftHTTP/AppDelegate.swift
+++ b/SwiftHTTP/AppDelegate.swift
@@ -19,19 +19,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
 		server = SwiftHTTP()
 		server?.headersReceivedHandler = { req in
-			println("headers: \(req.headers)")
+			print("headers: \(req.headers)")
 		}
 		server?.dataAvailableHandler = { req, data in
-			println("received \(data.length) bytes")
+			print("received \(data.length) bytes")
 		}
 		server?.responseHandler = { req, resp in
 			resp.body = "hello from SwiftHTTP".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
 		}
 
-		if let err = server?.listen(port: 3000) {
-			println("could not listen on port 3000: \(err)")
+		if let err = server?.listen(3000) {
+			print("could not listen on port 3000: \(err)")
 		} else {
-			println("listening on port \(server!.port)")
+			print("listening on port \(server!.port)")
 		}
 	}
 

--- a/SwiftHTTP/Info.plist
+++ b/SwiftHTTP/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.bytieful.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Changes:
- moved a lot of “var”s to “let”s
- println/print
- variable types: Int, Bool, …
- create const CFData “emtpyString” to clear out HTTPMessageBody
- added a lot of “!” as proposed by XCode

Overall I am not sure about all those changes (“what does that ! thing do there…”), just started to look into Swift. But the resulting code works, my Browser displayed the "hello from SwiftHTTP" message!

It might help to have somebody with more Swift/Swift2 experience review/correct those changes. :-D